### PR TITLE
Allow Vue app to load from and save to `MediaWiki:Rules`

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -101,23 +101,19 @@
 	},
 	"SpecialPages": {
 		"Rules": {
-			"class": "ProfessionalWiki\\Rules\\EntryPoints\\SpecialRules",
-			"services": [
-				"TitleFactory"
-			]
+			"class": "ProfessionalWiki\\Rules\\EntryPoints\\SpecialRules"
 		}
 	},
 	"Hooks": {
-		"BeforePageDisplay": "rules",
 		"ContentHandlerDefaultModelFor": "rules"
 	},
 	"HookHandlers": {
 		"rules": {
-			"class": "ProfessionalWiki\\Rules\\EntryPoints\\RulesHooks",
-			"services": [
-				"TitleFactory"
-			]
+			"class": "ProfessionalWiki\\Rules\\EntryPoints\\RulesHooks"
 		}
+	},
+	"ContentHandlers": {
+		"rules": "ProfessionalWiki\\Rules\\EntryPoints\\RulesContentHandler"
 	},
 	"type": "other"
 }

--- a/extension.json
+++ b/extension.json
@@ -43,6 +43,7 @@
 				"ext.rules/components/RuleConditions.vue",
 				"ext.rules/components/RulesTable.vue",
 				"ext.rules/composables/useRules.js",
+				"ext.rules/utils/rulePage.js",
 				"ext.rules/utils/ruleTransformers.js",
 				{
 					"name": "ext.rules/icons.json",

--- a/extension.json
+++ b/extension.json
@@ -105,7 +105,8 @@
 		}
 	},
 	"Hooks": {
-		"ContentHandlerDefaultModelFor": "rules"
+		"ContentHandlerDefaultModelFor": "rules",
+		"LoadExtensionSchemaUpdates": "rules"
 	},
 	"HookHandlers": {
 		"rules": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -31,5 +31,6 @@
 	"rules-table-action-add-category": "Add to category: $1",
 	"rules-notification-added-rule": "Added rule",
 	"rules-notification-updated-rule": "Updated rule",
-	"rules-notification-deleted-rule": "Deleted rule"
+	"rules-notification-deleted-rule": "Deleted rule",
+	"rules-bot-comment-init": "Initialize rules page"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,7 +7,6 @@
 			"Alistair3149"
 		]
 	},
-	"rules": "This page is used by Extension:Rules.",
 	"rules-message": "Rules",
 	"rules-description": "TODO",
 	"rules-table-caption": "Rules",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -7,7 +7,6 @@
 			"Alistair3149"
 		]
 	},
-	"rules": "Helper message on the MediaWiki:Rules page",
 	"rules-message": "{{name}}\nThe name of the extension",
 	"rules-description": "{{Desc|name=Rules|url=https://github.com/ProfessionalWiki/Rules}}",
 	"rules-table-caption": "The caption of the rules table",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -31,5 +31,6 @@
 	"rules-table-action-add-category": "The label of the action for the add category",
 	"rules-notification-added-rule": "The title of the notification for the added rule",
 	"rules-notification-updated-rule": "The title of the notification for the updated rule",
-	"rules-notification-deleted-rule": "The title of the notification for the deleted rule"
+	"rules-notification-deleted-rule": "The title of the notification for the deleted rule",
+	"rules-bot-comment-init": "The edit comment for the Rules Bot to initialize the MediaWiki:Rules page"
 }

--- a/modules/ext.rules/components/App.vue
+++ b/modules/ext.rules/components/App.vue
@@ -14,10 +14,22 @@
 </template>
 
 <script>
-const { defineComponent, ref } = require( 'vue' );
+const { defineComponent, ref, watch } = require( 'vue' );
 const EditRule = require( './EditRule.vue' );
 const RulesTable = require( './RulesTable.vue' );
 const { useRules } = require( '../composables/useRules.js' );
+
+/**
+ * @typedef {import('../types.js').Rule} Rule
+ */
+
+/**
+ * @return {Rule[] | undefined}
+ */
+function getInitialRules() {
+	// eslint-disable-next-line es-x/no-optional-chaining
+	return mw.config.get( 'rules' )?.value?.rules;
+}
 
 module.exports = defineComponent( {
 	name: 'App',
@@ -27,14 +39,9 @@ module.exports = defineComponent( {
 	},
 	setup() {
 		const isFormVisible = ref( false );
-		/** @type {import('vue').Ref<import('../types.js').Rule | null>} */
+		/** @type {import('vue').Ref<Rule | null>} */
 		const ruleToEdit = ref( null );
-		const { rules, addRule, updateRule, deleteRule } = useRules( getInitialRules() );
-
-		function getInitialRules() {
-			// eslint-disable-next-line es-x/no-optional-chaining
-			return mw.config.get( 'rules' )?.value?.rules;
-		}
+		const { rules, addRule, updateRule, deleteRule, saveRules } = useRules( getInitialRules() );
 
 		function onAddRule() {
 			ruleToEdit.value = null;
@@ -42,7 +49,7 @@ module.exports = defineComponent( {
 		}
 
 		/**
-		 * @param {import('../types.js').Rule} rule
+		 * @param {Rule} rule
 		 */
 		function onEditRule( rule ) {
 			ruleToEdit.value = rule;
@@ -50,7 +57,7 @@ module.exports = defineComponent( {
 		}
 
 		/**
-		 * @param {import('../types.js').Rule} rule
+		 * @param {Rule} rule
 		 */
 		function onDeleteRule( rule ) {
 			const deletedRule = deleteRule( rule );
@@ -63,7 +70,7 @@ module.exports = defineComponent( {
 		}
 
 		/**
-		 * @param {import('../types.js').Rule} rule
+		 * @param {Rule} rule
 		 */
 		function onSaveRule( rule ) {
 			const ruleBeingEdited = ruleToEdit.value;
@@ -83,6 +90,8 @@ module.exports = defineComponent( {
 				);
 			}
 		}
+
+		watch( rules, saveRules, { deep: true } );
 
 		return {
 			rules,

--- a/modules/ext.rules/components/App.vue
+++ b/modules/ext.rules/components/App.vue
@@ -18,18 +18,11 @@ const { defineComponent, ref, watch } = require( 'vue' );
 const EditRule = require( './EditRule.vue' );
 const RulesTable = require( './RulesTable.vue' );
 const { useRules } = require( '../composables/useRules.js' );
+const { getInitialRules } = require( '../utils/rulePage.js' );
 
 /**
  * @typedef {import('../types.js').Rule} Rule
  */
-
-/**
- * @return {Rule[] | undefined}
- */
-function getInitialRules() {
-	// eslint-disable-next-line es-x/no-optional-chaining
-	return mw.config.get( 'rules' )?.value?.rules;
-}
 
 module.exports = defineComponent( {
 	name: 'App',

--- a/modules/ext.rules/components/App.vue
+++ b/modules/ext.rules/components/App.vue
@@ -27,9 +27,14 @@ module.exports = defineComponent( {
 	},
 	setup() {
 		const isFormVisible = ref( false );
-		const { rules, addRule, updateRule, deleteRule } = useRules();
 		/** @type {import('vue').Ref<import('../types.js').Rule | null>} */
 		const ruleToEdit = ref( null );
+		const { rules, addRule, updateRule, deleteRule } = useRules( getInitialRules() );
+
+		function getInitialRules() {
+			// eslint-disable-next-line es-x/no-optional-chaining
+			return mw.config.get( 'rules' )?.value?.rules;
+		}
 
 		function onAddRule() {
 			ruleToEdit.value = null;

--- a/modules/ext.rules/components/RulesTable.vue
+++ b/modules/ext.rules/components/RulesTable.vue
@@ -3,13 +3,12 @@
 		v-model:sort="sort"
 		:caption="$i18n( 'rules-table-caption' ).text()"
 		:columns="tableData.length ? columns : []"
-		:pending="saving"
 		:data="tableData"
 		:use-row-headers="true"
 		@update:sort="onSort"
 	>
 		<template #header>
-			<cdx-button @click="$emit( 'add-rule' )">
+			<cdx-button v-if="canEdit" @click="$emit( 'add-rule' )">
 				<cdx-icon :icon="cdxIconAdd"></cdx-icon>
 				{{ $i18n( 'rules-table-add-rule' ).text() }}
 			</cdx-button>
@@ -19,7 +18,7 @@
 			{{ $i18n( 'rules-table-empty-state' ).text() }}
 		</template>
 
-		<template #item-more="{ row }">
+		<template v-if="canEdit" #item-more="{ row }">
 			<cdx-menu-button
 				v-model:selected="selection"
 				:menu-items="menuItems"
@@ -36,6 +35,7 @@
 const { defineComponent, ref, computed } = require( 'vue' );
 const { CdxButton, CdxIcon, CdxMenuButton, CdxTable } = require( '../../codex.js' );
 const { cdxIconAdd, cdxIconEdit, cdxIconEllipsis, cdxIconTrash } = require( '../icons.json' );
+const { isPageEditable } = require( '../utils/rulePage.js' );
 const { ruleToTableRow } = require( '../utils/ruleTransformers.js' );
 
 /** @type {import( '@wikimedia/codex' ).MenuItemData[]} */
@@ -71,6 +71,7 @@ module.exports = defineComponent( {
 	},
 	emits: [ 'add-rule', 'edit-rule', 'delete-rule' ],
 	setup( props, { emit } ) {
+		const canEdit = isPageEditable();
 		const selection = ref( null );
 		const sort = ref( { name: 'none' } );
 
@@ -130,6 +131,7 @@ module.exports = defineComponent( {
 		}
 
 		return {
+			canEdit,
 			sort,
 			selection,
 			columns,

--- a/modules/ext.rules/components/RulesTable.vue
+++ b/modules/ext.rules/components/RulesTable.vue
@@ -2,7 +2,8 @@
 	<cdx-table
 		v-model:sort="sort"
 		:caption="$i18n( 'rules-table-caption' ).text()"
-		:columns="columns"
+		:columns="tableData.length ? columns : []"
+		:pending="saving"
 		:data="tableData"
 		:use-row-headers="true"
 		@update:sort="onSort"

--- a/modules/ext.rules/composables/useRules.js
+++ b/modules/ext.rules/composables/useRules.js
@@ -1,5 +1,4 @@
 const { ref } = require( 'vue' );
-const { RuleActionType, RuleConditionType } = require( '../types.js' );
 
 /** @typedef {import('../types.js').Rule} Rule */
 
@@ -11,63 +10,13 @@ const { RuleActionType, RuleConditionType } = require( '../types.js' );
  * @property {( rule: Rule ) => Rule | null} deleteRule
  */
 
-/** @type {Rule[]} */
-const placeholderRules = [
-	{
-		name: 'Shorthair cats',
-		conditions: [
-			{
-				type: RuleConditionType.IN_CATEGORY,
-				categories: [ 'Siamese', 'British Shorthair', 'Abyssinian', 'Burmese' ]
-			}
-		],
-		actions: [
-			{
-				type: RuleActionType.ADD_CATEGORY,
-				category: 'Shorthair cats'
-			}
-		]
-	},
-	{
-		name: 'Mediumhair cats',
-		conditions: [
-			{
-				type: RuleConditionType.IN_CATEGORY,
-				categories: [ 'American Bobtail', 'Birman', 'Ragdoll', 'Siberian' ]
-			}
-		],
-		actions: [
-			{
-				type: RuleActionType.ADD_CATEGORY,
-				category: 'Mediumhair cats'
-			}
-		]
-	},
-	{
-		name: 'Longhair cats',
-		conditions: [
-			{
-				type: RuleConditionType.IN_CATEGORY,
-				categories: [ 'Persian', 'Maine Coon', 'Norwegian Forest Cat', 'Himalayan' ]
-			}
-		],
-		actions: [
-			{
-				type: RuleActionType.ADD_CATEGORY,
-				category: 'Longhair cats'
-			}
-		]
-	}
-];
-
 /**
  * @param {Rule[]} [initialRules]
  * @return {RulesComposable}
  */
-function useRules( initialRules ) {
-	// TODO: Refactor the rules injection when the API is ready
+function useRules( initialRules = [] ) {
 	/** @type {import('vue').Ref<Rule[]>} */
-	const rules = ref( [ ...( initialRules || placeholderRules ) ] );
+	const rules = ref( [ ...initialRules ] );
 
 	/**
 	 * @param {Rule} rule

--- a/modules/ext.rules/utils/rulePage.js
+++ b/modules/ext.rules/utils/rulePage.js
@@ -1,0 +1,19 @@
+/**
+ * @return {import('../types.js').Rule[] | undefined}
+ */
+function getInitialRules() {
+	// eslint-disable-next-line es-x/no-optional-chaining
+	return mw.config.get( 'rules' )?.value?.rules;
+}
+
+/**
+ * @return {boolean}
+ */
+function isPageEditable() {
+	return mw.config.get( 'wgIsProbablyEditable' ) || false;
+}
+
+module.exports = {
+	getInitialRules,
+	isPageEditable
+};

--- a/src/EntryPoints/RulesContent.php
+++ b/src/EntryPoints/RulesContent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\Rules\EntryPoints;
+
+use MediaWiki\Content\JsonContent;
+use ProfessionalWiki\Rules\RulesExtension;
+
+class RulesContent extends JsonContent {
+
+	public function __construct( $text, $modelId = RulesExtension::RULES_CONTENT_MODEL ) {
+		parent::__construct( $text, $modelId );
+	}
+}

--- a/src/EntryPoints/RulesContentHandler.php
+++ b/src/EntryPoints/RulesContentHandler.php
@@ -14,7 +14,7 @@ use ProfessionalWiki\Rules\RulesExtension;
 class RulesContentHandler extends JsonContentHandler {
 
 	public function __construct( $modelId = RulesExtension::RULES_CONTENT_MODEL ) {
-		parent::__construct( $modelId, [ RulesExtension::RULES_CONTENT_MODEL ] );
+		parent::__construct( $modelId );
 	}
 
 	protected function getContentClass(): string {
@@ -43,10 +43,10 @@ class RulesContentHandler extends JsonContentHandler {
 		Content $content,
 		ContentParseParams $cpoParams,
 		ParserOutput &$output
-	) {
+	): void {
 		$output = new ParserOutput();
 
-		$output->addModules( [ 'ext.rules' ] );
 		$output->setRawText( '<div id="ext-rules-app"></div>' );
+		$output->addModules( [ 'ext.rules' ] );
 	}
 }

--- a/src/EntryPoints/RulesContentHandler.php
+++ b/src/EntryPoints/RulesContentHandler.php
@@ -44,8 +44,8 @@ class RulesContentHandler extends JsonContentHandler {
 		ContentParseParams $cpoParams,
 		ParserOutput &$output
 	): void {
-		$output = new ParserOutput();
-
+		/** @var RulesContent $content */
+		$output->setJsConfigVar( 'rules', $content->getData() );
 		$output->setRawText( '<div id="ext-rules-app"></div>' );
 		$output->addModules( [ 'ext.rules' ] );
 	}

--- a/src/EntryPoints/RulesContentHandler.php
+++ b/src/EntryPoints/RulesContentHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\Rules\EntryPoints;
+
+use MediaWiki\Content\Content;
+use MediaWiki\Content\Renderer\ContentParseParams;
+use MediaWiki\Content\JsonContentHandler;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\Title;
+use ProfessionalWiki\Rules\RulesExtension;
+
+class RulesContentHandler extends JsonContentHandler {
+
+	public function __construct( $modelId = RulesExtension::RULES_CONTENT_MODEL ) {
+		parent::__construct( $modelId, [ RulesExtension::RULES_CONTENT_MODEL ] );
+	}
+
+	protected function getContentClass(): string {
+		return RulesContent::class;
+	}
+
+	public function makeEmptyContent() {
+		return new RulesContent( RulesExtension::RULES_DEFAULT_CONFIG );
+	}
+
+	public function canBeUsedOn( Title $title ) {
+		return RulesExtension::getInstance()->isRulesPage( $title );
+	}
+
+	public function supportsDirectEditing(): bool {
+		// TODO: Need to decide if we want to allow direct editing
+		return true;
+	}
+
+	// So that it can be edited by the Vue app
+	public function supportsDirectApiEditing(): bool {
+		return true;
+	}
+
+	protected function fillParserOutput(
+		Content $content,
+		ContentParseParams $cpoParams,
+		ParserOutput &$output
+	) {
+		$output = new ParserOutput();
+
+		$output->addModules( [ 'ext.rules' ] );
+		$output->setRawText( '<div id="ext-rules-app"></div>' );
+	}
+}

--- a/src/EntryPoints/RulesHooks.php
+++ b/src/EntryPoints/RulesHooks.php
@@ -4,45 +4,15 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\Rules\EntryPoints;
 
-use MediaWiki\Output\Hook\BeforePageDisplayHook;
 use MediaWiki\Revision\Hook\ContentHandlerDefaultModelForHook;
-use MediaWiki\Title\Title;
-use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\Rules\RulesExtension;
 
-class RulesHooks implements BeforePageDisplayHook, ContentHandlerDefaultModelForHook {
-
-	public function __construct(
-		private TitleFactory $titleFactory
-	) {
-	}
-
-	public function onBeforePageDisplay( $out, $skin ): void {
-		$title = $out->getTitle();
-
-		if (
-			$title === null ||
-			$out->getActionName() !== 'view' ||
-			!$this->isRulesPage( $title )
-		) {
-			return;
-		}
-
-		// Add entry point for the Vue app
-		$out->addHTML( '<div id="ext-rules-app"></div>' );
-
-		$out->addModules( 'ext.rules' );
-	}
+class RulesHooks implements ContentHandlerDefaultModelForHook {
 
 	public function onContentHandlerDefaultModelFor( $title, &$model ): void {
-		if ( $this->isRulesPage( $title ) ) {
-			$model = CONTENT_MODEL_JSON;
+		if ( RulesExtension::getInstance()->isRulesPage( $title ) ) {
+			$model = RulesExtension::RULES_CONTENT_MODEL;
 		}
-	}
-
-	private function isRulesPage( Title $title ): bool {
-		return $this->titleFactory->newFromText( RulesExtension::RULES_PAGE_TITLE, NS_MEDIAWIKI )
-			?->equals( $title ) ?? false;
 	}
 
 }

--- a/src/EntryPoints/RulesHooks.php
+++ b/src/EntryPoints/RulesHooks.php
@@ -4,15 +4,32 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\Rules\EntryPoints;
 
+use MediaWiki\CommentStore\CommentStoreComment;
 use MediaWiki\Revision\Hook\ContentHandlerDefaultModelForHook;
+use MediaWiki\Revision\SlotRecord;
+use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
 use ProfessionalWiki\Rules\RulesExtension;
 
-class RulesHooks implements ContentHandlerDefaultModelForHook {
+class RulesHooks implements ContentHandlerDefaultModelForHook, LoadExtensionSchemaUpdatesHook {
 
 	public function onContentHandlerDefaultModelFor( $title, &$model ): void {
 		if ( RulesExtension::getInstance()->isRulesPage( $title ) ) {
 			$model = RulesExtension::RULES_CONTENT_MODEL;
 		}
+	}
+
+	public function onLoadExtensionSchemaUpdates( $updater ): void {
+		$rulesExtension = RulesExtension::getInstance();
+		$title = $rulesExtension->getRulesPageTitle();
+
+		if ( $title === null || $title->exists() ) {
+			return;
+		}
+
+		$pageUpdater = $rulesExtension->getRulesPageUpdater( $title );
+
+		$pageUpdater->setContent( SlotRecord::MAIN, new RulesContent( RulesExtension::RULES_DEFAULT_CONFIG ) );
+		$pageUpdater->saveRevision( CommentStoreComment::newUnsavedComment( $rulesExtension->getEditCommentForRulesPageInit() ) );
 	}
 
 }

--- a/src/EntryPoints/SpecialRules.php
+++ b/src/EntryPoints/SpecialRules.php
@@ -6,21 +6,18 @@ namespace ProfessionalWiki\Rules\EntryPoints;
 
 use MediaWiki\Message\Message;
 use MediaWiki\SpecialPage\SpecialPage;
-use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\Rules\RulesExtension;
 
 class SpecialRules extends SpecialPage {
 
-	public function __construct(
-		private TitleFactory $titleFactory
-	) {
+	public function __construct() {
 		parent::__construct( 'Rules' );
 	}
 
 	public function execute( $subPage ): void {
 		parent::execute( $subPage );
 
-		$title = $this->titleFactory->newFromText( RulesExtension::RULES_PAGE_TITLE, NS_MEDIAWIKI );
+		$title = RulesExtension::getInstance()->getRulesPageTitle();
 
 		if ( $title !== null ) {
 			$this->getOutput()->redirect( $title->getFullURL() );

--- a/src/RulesExtension.php
+++ b/src/RulesExtension.php
@@ -4,15 +4,32 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\Rules;
 
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
+
 class RulesExtension {
 
 	public const RULES_PAGE_TITLE = 'Rules';
+	public const RULES_CONTENT_MODEL = 'rules';
+
+	public const RULES_DEFAULT_CONFIG = '{
+	"rules": []
+}';
 
 	public static function getInstance(): self {
 		/** @var ?RulesExtension $instance */
 		static $instance = null;
 		$instance ??= new self();
 		return $instance;
+	}
+
+	public function isRulesPage( Title $title ): bool {
+		return $this->getRulesPageTitle()?->equals( $title ) ?? false;
+	}
+
+	public function getRulesPageTitle(): ?Title {
+		return MediaWikiServices::getInstance()->getTitleFactory()
+			->newFromText( self::RULES_PAGE_TITLE, NS_MEDIAWIKI );
 	}
 
 }

--- a/src/RulesExtension.php
+++ b/src/RulesExtension.php
@@ -5,12 +5,19 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\Rules;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Message\Message;
+use MediaWiki\Storage\PageUpdater;
 use MediaWiki\Title\Title;
+use MediaWiki\User\User;
+use RuntimeException;
 
 class RulesExtension {
 
 	public const RULES_PAGE_TITLE = 'Rules';
+
 	public const RULES_CONTENT_MODEL = 'rules';
+
+	public const RULES_SYSTEM_USER = 'Rules Bot';
 
 	public const RULES_DEFAULT_CONFIG = '{
 	"rules": []
@@ -30,6 +37,26 @@ class RulesExtension {
 	public function getRulesPageTitle(): ?Title {
 		return MediaWikiServices::getInstance()->getTitleFactory()
 			->newFromText( self::RULES_PAGE_TITLE, NS_MEDIAWIKI );
+	}
+
+	public function getRulesPageUpdater( Title $title ): PageUpdater {
+		$user = $this->getRulesSystemUser();
+
+		if ( $user === null ) {
+			throw new RuntimeException( 'Failed to create system user' );
+		}
+
+		return MediaWikiServices::getInstance()->getPageUpdaterFactory()
+			->newPageUpdater( $title, $user );
+	}
+
+	public function getRulesSystemUser(): ?User {
+		// TODO: Add i18n for the system user name?
+		return User::newSystemUser( self::RULES_SYSTEM_USER, [ 'steal' => true ] );
+	}
+
+	public function getEditCommentForRulesPageInit(): Message {
+		return new Message( 'rules-bot-comment-init' );
 	}
 
 }


### PR DESCRIPTION
Key changes
- Allow the Vue app to load and save data to page content
- Create a custom content model for the Rules definition instead of using just JSON, with the benefits of:
  - The ResourceLoader modules are only loaded on pages with the `rules` content model (restricted to `MediaWiki:Rules` only), which allows us to save the module to the parser cache instead of doing a manual check with `BeforePageOutput` (which runs on every page)
  - Content handler comes with methods that can be used for validation of the data structure
- Initialize `MediaWiki:Rules` with empty rules data when `update.php` is run and the page does not exist
- Hide all rules edit actions when user has no permission to edit the page
- Fix incorrect table empty state display