### PR TITLE
Trigger use case on parser output update

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -110,7 +110,8 @@
 	},
 	"Hooks": {
 		"BeforePageDisplay": "rules",
-		"ContentHandlerDefaultModelFor": "rules"
+		"ContentHandlerDefaultModelFor": "rules",
+		"ContentAlterParserOutput": "rules"
 	},
 	"HookHandlers": {
 		"rules": {

--- a/src/Application/ApplyRulesUseCase.php
+++ b/src/Application/ApplyRulesUseCase.php
@@ -4,6 +4,8 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\Rules\Application;
 
+use MediaWiki\Parser\ParserOutput;
+
 class ApplyRulesUseCase {
 
 	public function __construct(
@@ -11,14 +13,16 @@ class ApplyRulesUseCase {
 	) {
 	}
 
-	public function applyToPage( /* TODO: some page identifier */ ): void {
+	public function applyToPage( ParserOutput $parserOutput ): void {
 		$rules = $this->ruleListLookup->getAllRules();
 
-		$presentCategories = []; // TODO: get categories from page
+		$presentCategories = $parserOutput->getCategoryNames();
 
 		$categoriesToAdd = $rules->run( $presentCategories );
 
-		shuffle( $categoriesToAdd ); // TODO: add categories to page
+		foreach ( $categoriesToAdd as $category ) {
+			$parserOutput->addCategory( $category );
+		}
 	}
 
 }

--- a/src/EntryPoints/RulesHooks.php
+++ b/src/EntryPoints/RulesHooks.php
@@ -4,13 +4,14 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\Rules\EntryPoints;
 
+use MediaWiki\Content\Hook\ContentAlterParserOutputHook;
 use MediaWiki\Output\Hook\BeforePageDisplayHook;
 use MediaWiki\Revision\Hook\ContentHandlerDefaultModelForHook;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use ProfessionalWiki\Rules\RulesExtension;
 
-class RulesHooks implements BeforePageDisplayHook, ContentHandlerDefaultModelForHook {
+class RulesHooks implements BeforePageDisplayHook, ContentHandlerDefaultModelForHook, ContentAlterParserOutputHook {
 
 	public function __construct(
 		private TitleFactory $titleFactory
@@ -43,6 +44,10 @@ class RulesHooks implements BeforePageDisplayHook, ContentHandlerDefaultModelFor
 	private function isRulesPage( Title $title ): bool {
 		return $this->titleFactory->newFromText( RulesExtension::RULES_PAGE_TITLE, NS_MEDIAWIKI )
 			?->equals( $title ) ?? false;
+	}
+
+	public function onContentAlterParserOutput( $content, $title, $parserOutput ) {
+		RulesExtension::getInstance()->newApplyRulesUseCase()->applyToPage( $parserOutput );
 	}
 
 }

--- a/src/RulesExtension.php
+++ b/src/RulesExtension.php
@@ -4,6 +4,12 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\Rules;
 
+use MediaWiki\MediaWikiServices;
+use ProfessionalWiki\Rules\Application\ApplyRulesUseCase;
+use ProfessionalWiki\Rules\Application\RuleListLookup;
+use ProfessionalWiki\Rules\Persistence\PageRuleListLookup;
+use ProfessionalWiki\Rules\Persistence\RulesDeserializer;
+
 class RulesExtension {
 
 	public const RULES_PAGE_TITLE = 'Rules';
@@ -13,6 +19,24 @@ class RulesExtension {
 		static $instance = null;
 		$instance ??= new self();
 		return $instance;
+	}
+
+	public function newApplyRulesUseCase(): ApplyRulesUseCase {
+		return new ApplyRulesUseCase(
+			ruleListLookup: $this->newPageRuleListLookup()
+		);
+	}
+
+	private function newPageRuleListLookup(): RuleListLookup {
+		return new PageRuleListLookup(
+			titleFactory: MediaWikiServices::getInstance()->getTitleFactory(),
+			wikiPageFactory: MediaWikiServices::getInstance()->getWikiPageFactory(),
+			deserializer: $this->newRulesDeserializer()
+		);
+	}
+
+	private function newRulesDeserializer(): RulesDeserializer {
+		return new RulesDeserializer();
 	}
 
 }

--- a/tests/phpunit/Integration/ApplyRulesUseCaseIntegrationTest.php
+++ b/tests/phpunit/Integration/ApplyRulesUseCaseIntegrationTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\Rules\Tests\Integration;
+
+use MediaWiki\Title\Title;
+use ProfessionalWiki\Rules\Tests\RulesIntegrationTest;
+use ProfessionalWiki\Rules\Tests\Valid;
+
+/**
+ * @covers \ProfessionalWiki\Rules\Application\ApplyRulesUseCase
+ * @covers \ProfessionalWiki\Rules\EntryPoints\RulesHooks::onContentAlterParserOutput
+ * @group Database
+ */
+class ApplyRulesUseCaseIntegrationTest extends RulesIntegrationTest {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->editConfigPage( Valid::configJson() );
+	}
+
+	public function testCategoryGetsAddedIfRuleMatchesOnPageCreation(): void {
+		$title = $this->newTestPage();
+
+		$this->insertPage( $title, '[[Category:ConditionCategory]]' );
+
+		$this->assertPageHasCategories(
+			$title,
+			[ 'ConditionCategory', 'ActionCategory' ]
+		);
+	}
+
+	private function newTestPage(): Title {
+		return Title::newFromText( 'Test Page' );
+	}
+
+	/**
+	 * @param string[] $categories
+	 */
+	private function assertPageHasCategories( Title $title, array $categories ): void {
+		$parserOutput = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $title )->getParserOutput();
+
+		$this->assertSame(
+			$parserOutput === false ? [] : $parserOutput->getCategoryNames(),
+			$categories
+		);
+	}
+
+	public function testCategoryDoesNotGetAddedIfNoRuleMatchesOnPageCreation(): void {
+		$title = $this->newTestPage();
+
+		$this->insertPage( $title, '[[Category:NotConditionCategory]]' );
+
+		$this->assertPageHasCategories(
+			$title,
+			[ 'NotConditionCategory' ]
+		);
+	}
+
+	public function testCategoryGetsAddedIfRuleMatchesOnPageEdit(): void {
+		$title = $this->newTestPage();
+		$this->insertPage( $title, '[[Category:NotConditionCategory]]' );
+
+		$this->editPage( $title, '[[Category:NotConditionCategory]] [[Category:ConditionCategory]]' );
+
+		$this->assertPageHasCategories(
+			$title,
+			[ 'NotConditionCategory', 'ConditionCategory', 'ActionCategory' ]
+		);
+	}
+
+	public function testCategoryDoesNotGetAddedIfNoRuleMatchesOnPageEdit(): void {
+		$title = $this->newTestPage();
+		$this->insertPage( $title, '[[Category:NotConditionCategory]]' );
+
+		$this->editPage( $title, '[[Category:NotConditionCategory]] [[Category:StillNotConditionCategory]]' );
+
+		$this->assertPageHasCategories(
+			$title,
+			[ 'NotConditionCategory', 'StillNotConditionCategory' ]
+		);
+	}
+
+	public function testPreviouslyAddedRuleCategoryIsKeptWhenNonMatchingCategoryIsAdded(): void {
+		$title = $this->newTestPage();
+		$this->insertPage( $title, '[[Category:ConditionCategory]]' );
+
+		$this->editPage( $title, '[[Category:ConditionCategory]] [[Category:NotConditionCategory]]' );
+
+		$this->assertPageHasCategories(
+			$title,
+			[ 'ConditionCategory', 'NotConditionCategory', 'ActionCategory' ]
+		);
+	}
+
+	public function testPreviouslyAddedRuleCategoryIsRemovedWhenPreviouslyMatchingCategoryIsRemoved(): void {
+		$title = $this->newTestPage();
+		$this->insertPage( $title, '[[Category:ConditionCategory]]' );
+
+		$this->editPage( $title, '[[Category:NotConditionCategory]]' );
+
+		$this->assertPageHasCategories(
+			$title,
+			[ 'NotConditionCategory' ]
+		);
+	}
+
+	public function testPreviouslyAddedRuleCategoryIsNotRemovedWhenPageIsNotEditedAfterConfigChange(): void {
+		$title = $this->newTestPage();
+		$this->insertPage( $title, '[[Category:ConditionCategory]]' );
+
+		$this->editConfigPage( Valid::configJsonForNoRules() );
+
+		$this->assertPageHasCategories(
+			$title,
+			[ 'ConditionCategory', 'ActionCategory' ]
+		);
+	}
+
+	public function testPreviouslyAddedRuleCategoryIsRemovedWhenPageIsEditedAfterConfigChange(): void {
+		$title = $this->newTestPage();
+		$this->insertPage( $title, '[[Category:ConditionCategory]]' );
+
+		$this->editConfigPage( Valid::configJsonForNoRules() );
+		$this->editPage( $title, '[[Category:ConditionCategory]]' );
+
+		$this->assertPageHasCategories(
+			$title,
+			[ 'ConditionCategory' ]
+		);
+	}
+
+}

--- a/tests/phpunit/RulesIntegrationTest.php
+++ b/tests/phpunit/RulesIntegrationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\Rules\Tests;
+
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use ProfessionalWiki\Rules\RulesExtension;
+
+class RulesIntegrationTest extends MediaWikiIntegrationTestCase {
+
+	protected function editConfigPage( string $config ): void {
+		$this->editPage(
+			Title::newFromText( RulesExtension::RULES_PAGE_TITLE, NS_MEDIAWIKI ),
+			$config
+		);
+	}
+
+}

--- a/tests/phpunit/Valid.php
+++ b/tests/phpunit/Valid.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\Rules\Tests;
+
+class Valid {
+
+	public static function configJsonForNoRules(): string {
+		return '{ "rules": [] }';
+	}
+
+	public static function configJson(): string {
+		return <<<'JSON'
+{
+	"rules": [
+		{
+			"conditions": [
+				{
+					"type": "inCategory",
+					"categories": [ "ConditionCategory" ]
+				}
+			],
+			"actions": [
+				{
+					"category": "ActionCategory"
+				}
+			]
+		}
+	]
+}
+JSON;
+	}
+
+}


### PR DESCRIPTION
Closes https://github.com/ProfessionalWiki/Rules/issues/16

Alternative to https://github.com/ProfessionalWiki/Rules/pull/24

* Does not require changing wikitext
* Hooks into a whole different route where the categories are applied when the parser output is (re-)created (page edits, cache clear)
* Already works, unlike #24

----

Example of this working:

Rendered page:
<img width="838" height="266" alt="Screenshot_20250724_140906" src="https://github.com/user-attachments/assets/8ce1dcce-5331-4bc2-ae7e-89a853325314" />

Page source:
<img width="838" height="328" alt="Screenshot_20250724_140922" src="https://github.com/user-attachments/assets/54263b50-bbdd-4d46-ab54-9c90f47fb12d" />

Rules:
```json
{
	"rules": [
		{
			"name": "Shorthair cats",
			"conditions": [
				{
					"type": "inCategory",
					"categories": [
						"Siamese"
					]
				}
			],
			"actions": [
				{
					"type": "addCategory",
					"category": "Shorthair cats"
				}
			]
		},
		{
			"name": "Foo",
			"conditions": [
				{
					"type": "inCategory",
					"categories": [
						"Foo",
						"Foo Bar"
					]
				}
			],
			"actions": [
				{
					"type": "addCategory",
					"category": "AutoFoo"
				}
			]
		}
	]
}
```