### PR TITLE
Purge all pages in maintenance script

### DIFF
--- a/maintenance/ApplyRules.php
+++ b/maintenance/ApplyRules.php
@@ -4,7 +4,10 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\Rules\Maintenance;
 
-use Maintenance;
+use MediaWiki\Deferred\LinksUpdate\LinksUpdate;
+use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Page\PageRecord;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 require_once $basePath . '/maintenance/Maintenance.php';
@@ -19,7 +22,29 @@ class ApplyRules extends Maintenance {
 	}
 
 	public function execute() {
-		// TODO: Implement execute() method.
+		$services = MediaWikiServices::getInstance();
+		$pageRecords = $services->getPageStore()->newSelectQueryBuilder()->fetchPageRecords();
+		$wikiPageFactory = $services->getWikiPageFactory();
+		$pageCount = 0;
+
+		foreach ( $pageRecords as $pageRecord ) {
+			/** @var PageRecord $pageRecord */
+			$page = $wikiPageFactory->newFromTitle( $pageRecord );
+			$categoryCountBefore = count( $page->getCategories() );
+
+			// Get ParserOutput without cache to trigger onContentAlterParserOutput
+			( new LinksUpdate( $page->getTitle(), $page->getParserOutput( noCache: true ) ) )->doUpdate();
+			$page->doPurge();
+
+			$titleText = $page->getTitle()->getPrefixedText();
+			$categoryCountAfter = count( $page->getCategories() );
+
+			$this->output( "Applied rules on {$titleText} ($categoryCountBefore -> $categoryCountAfter)\n" );
+
+			$pageCount += 1;
+		}
+
+		$this->output( "Done. Applied rules on $pageCount pages\n" );
 	}
 
 }

--- a/tests/phpunit/Integration/ApplyRulesUseCaseIntegrationTest.php
+++ b/tests/phpunit/Integration/ApplyRulesUseCaseIntegrationTest.php
@@ -35,18 +35,6 @@ class ApplyRulesUseCaseIntegrationTest extends RulesIntegrationTest {
 		return Title::newFromText( 'Test Page' );
 	}
 
-	/**
-	 * @param string[] $categories
-	 */
-	private function assertPageHasCategories( Title $title, array $categories ): void {
-		$parserOutput = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $title )->getParserOutput();
-
-		$this->assertSame(
-			$parserOutput === false ? [] : $parserOutput->getCategoryNames(),
-			$categories
-		);
-	}
-
 	public function testCategoryDoesNotGetAddedIfNoRuleMatchesOnPageCreation(): void {
 		$title = $this->newTestPage();
 

--- a/tests/phpunit/Maintenance/ApplyRulesTest.php
+++ b/tests/phpunit/Maintenance/ApplyRulesTest.php
@@ -5,14 +5,15 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\Rules\Tests\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
-use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\Rules\Maintenance\ApplyRules;
+use ProfessionalWiki\Rules\Tests\RulesIntegrationTest;
+use ProfessionalWiki\Rules\Tests\Valid;
 
 /**
  * @covers \ProfessionalWiki\Rules\Maintenance\ApplyRules
  * @group Database
  */
-class ApplyRulesTest extends MediaWikiIntegrationTestCase {
+class ApplyRulesTest extends RulesIntegrationTest {
 
 	private Maintenance $maintenance;
 
@@ -28,10 +29,51 @@ class ApplyRulesTest extends MediaWikiIntegrationTestCase {
 		parent::tearDown();
 	}
 
-	public function testTODO(): void {
+	public function testAppliesNothingIfThereAreNoPages() {
 		$this->maintenance->execute();
 
-		$this->assertTrue( true ); // TODO
+		$this->expectOutputRegex( '/Applied rules on 0 pages/' );
+	}
+
+	public function testAppliesRulesOnAllPagesInAllNamespaces() {
+		$this->editConfigPage( Valid::configJson() );
+		$this->insertPage( 'Page One', '[[Category:ConditionCategory]]' );
+		$this->insertPage( 'Category One', '', NS_CATEGORY );
+		$this->insertPage( 'Page Two', '' );
+		$this->insertPage( 'SomeConfig', '', NS_MEDIAWIKI );
+		$this->insertPage( 'Page Three', '[[Category:ConditionCategory]]' );
+
+		$this->maintenance->execute();
+
+		$this->expectOutputRegex( '/Applied rules on 6 pages/' );
+	}
+
+	public function testNewCategoryIsAdded() {
+		$this->editConfigPage( Valid::configJsonForNoRules() );
+		$pageOne = $this->createPageWithText();
+		$pageTwo = $this->createPageWithText( '[[Category:ConditionCategory]]' );
+		$pageThree = $this->createPageWithText();
+		$this->editConfigPage( Valid::configJson() );
+
+		$this->maintenance->execute();
+
+		$this->assertPageHasCategories( $pageOne->getTitle(), [] );
+		$this->assertPageHasCategories( $pageTwo->getTitle(), [ 'ConditionCategory', 'ActionCategory' ] );
+		$this->assertPageHasCategories( $pageThree->getTitle(), [] );
+	}
+
+	public function testOldCategoryIsRemoved() {
+		$this->editConfigPage( Valid::configJson() );
+		$pageOne = $this->createPageWithText();
+		$pageTwo = $this->createPageWithText( '[[Category:ConditionCategory]]' );
+		$pageThree = $this->createPageWithText();
+		$this->editConfigPage( Valid::configJsonForNoRules() );
+
+		$this->maintenance->execute();
+
+		$this->assertPageHasCategories( $pageOne->getTitle(), [] );
+		$this->assertPageHasCategories( $pageTwo->getTitle(), [ 'ConditionCategory' ] );
+		$this->assertPageHasCategories( $pageThree->getTitle(), [] );
 	}
 
 }

--- a/tests/phpunit/RulesIntegrationTest.php
+++ b/tests/phpunit/RulesIntegrationTest.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\Rules\Tests;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\Rules\RulesExtension;
+use WikiPage;
 
 class RulesIntegrationTest extends MediaWikiIntegrationTestCase {
 
@@ -14,6 +15,31 @@ class RulesIntegrationTest extends MediaWikiIntegrationTestCase {
 		$this->editPage(
 			Title::newFromText( RulesExtension::RULES_PAGE_TITLE, NS_MEDIAWIKI ),
 			$config
+		);
+	}
+
+	protected function createPageWithText( string $text = 'Whatever wikitext' ): WikiPage {
+		$page = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $this->createUniqueTitle() );
+
+		$this->editPage( $page, $text );
+
+		return $page;
+	}
+
+	private function createUniqueTitle(): Title {
+		static $pageCounter = 0;
+		return Title::newFromText( 'RulesTestPage' . ++$pageCounter );
+	}
+
+	/**
+	 * @param string[] $categories
+	 */
+	public function assertPageHasCategories( Title $title, array $categories ): void {
+		$parserOutput = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $title )->getParserOutput();
+
+		$this->assertSame(
+			$parserOutput === false ? [] : $parserOutput->getCategoryNames(),
+			$categories
 		);
 	}
 


### PR DESCRIPTION
Based on the parser approach in https://github.com/ProfessionalWiki/Rules/pull/31
Essentially https://www.mediawiki.org/wiki/Manual:PurgePage.php called on all pages. 

Follow-up TODO thoughts:
* limit pages where rules should apply?
* limit number of pages to purge in a single run?
* purge page only if any rule is going to cause a change?