### PR TITLE
Fix menu being hidden by table container

### DIFF
--- a/modules/ext.rules/components/RulesTable.vue
+++ b/modules/ext.rules/components/RulesTable.vue
@@ -145,3 +145,10 @@ module.exports = defineComponent( {
 	}
 } );
 </script>
+
+<style lang="less">
+// HACK: Set to position:fixed so that the menu won't be clipped by the table container (#36)
+.cdx-table .cdx-toggle-button--toggled-on + .cdx-menu-button__menu-wrapper {
+	position: fixed;
+}
+</style>


### PR DESCRIPTION
Fixes: #36

<img width="639" height="355" alt="image" src="https://github.com/user-attachments/assets/b6fd82f2-8ec7-416c-b1d4-b204c0ab0b19" />
