### PR TITLE
Normalize categories in use case

### DIFF
--- a/src/Application/ApplyRulesUseCase.php
+++ b/src/Application/ApplyRulesUseCase.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\Rules\Application;
 
 use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\TitleValue;
 
 class ApplyRulesUseCase {
 
@@ -16,13 +17,24 @@ class ApplyRulesUseCase {
 	public function applyToPage( ParserOutput $parserOutput ): void {
 		$rules = $this->ruleListLookup->getAllRules();
 
-		$presentCategories = $parserOutput->getCategoryNames();
+		$presentCategories = $this->normalizeCategories( $parserOutput->getCategoryNames() );
 
 		$categoriesToAdd = $rules->run( $presentCategories );
 
 		foreach ( $categoriesToAdd as $category ) {
 			$parserOutput->addCategory( $category );
 		}
+	}
+
+	/**
+	 * @param string[] $categories
+	 * @return string[]
+	 */
+	private function normalizeCategories( array $categories ): array {
+		return array_map(
+			fn( string $category ) => TitleValue::tryNew( NS_CATEGORY, $category )?->getText() ?? '',
+			$categories
+		);
 	}
 
 }

--- a/tests/phpunit/Integration/ApplyRulesUseCaseIntegrationTest.php
+++ b/tests/phpunit/Integration/ApplyRulesUseCaseIntegrationTest.php
@@ -119,4 +119,38 @@ class ApplyRulesUseCaseIntegrationTest extends RulesIntegrationTest {
 		);
 	}
 
+	/**
+	 * @dataProvider provideMatchingCategoryTestCases
+	 */
+	public function testCategoryGetsAddedWhenNormalizedPageCategoryMatches( string $category ): void {
+		$title = $this->newTestPage();
+
+		$this->insertPage( $title, "[[Category:$category]]" );
+
+		$this->assertPageHasCategories(
+			$title,
+			[ 'Condition Category', 'Action Category' ]
+		);
+	}
+
+	public static function provideMatchingCategoryTestCases(): \Generator {
+		yield 'space inside' => [ 'Condition Category' ];
+		yield 'starting space' => [ ' Condition Category' ];
+		yield 'ending space' => [ 'Condition Category ' ];
+		yield 'underscore inside' => [ 'Condition_Category' ];
+		yield 'starting space with underscore inside' => [ ' Condition_Category' ];
+		yield 'ending space with underscore inside' => [ 'Condition_Category ' ];
+	}
+
+	public function testCategoryDoesNotGetAddedWhenNormalizedPageCategoryDoesNotMatch(): void {
+		$title = $this->newTestPage();
+
+		$this->insertPage( $title, "[[Category:Condition category]]" );
+
+		$this->assertPageHasCategories(
+			$title,
+			[ 'Condition category' ]
+		);
+	}
+
 }

--- a/tests/phpunit/RulesIntegrationTest.php
+++ b/tests/phpunit/RulesIntegrationTest.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\Rules\Tests;
 
 use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleValue;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\Rules\RulesExtension;
 use WikiPage;
@@ -37,8 +38,14 @@ class RulesIntegrationTest extends MediaWikiIntegrationTestCase {
 	public function assertPageHasCategories( Title $title, array $categories ): void {
 		$parserOutput = $this->getServiceContainer()->getWikiPageFactory()->newFromTitle( $title )->getParserOutput();
 
+		// Normalize to "text form" to make assertions consistent.
+		$normalizedCategories = array_map(
+			fn( string $category ) => TitleValue::tryNew( NS_CATEGORY, $category )?->getText() ?? '',
+			$parserOutput === false ? [] : $parserOutput->getCategoryNames()
+		);
+
 		$this->assertSame(
-			$parserOutput === false ? [] : $parserOutput->getCategoryNames(),
+			$normalizedCategories,
 			$categories
 		);
 	}

--- a/tests/phpunit/Valid.php
+++ b/tests/phpunit/Valid.php
@@ -28,6 +28,21 @@ class Valid {
 					"category": "ActionCategory"
 				}
 			]
+		},
+		{
+			"name": "Valid Rule With Spaces",
+			"conditions": [
+				{
+					"type": "inCategory",
+					"categories": [ "Condition Category" ]
+				}
+			],
+			"actions": [
+				{
+					"type": "addCategory",
+					"category": "Action Category"
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
For #48 

This only normalizes the categories in the use case. If the config is edited manually with non-normalized format (like underscores), then the rule condition will not match. This can be done in a follow-up.