### PR TITLE
Fix space position in comma separated category list

### DIFF
--- a/modules/ext.rules/components/RulesTable.vue
+++ b/modules/ext.rules/components/RulesTable.vue
@@ -41,8 +41,7 @@
 								class="ext-rules-table-link"
 							>
 								{{ link.label }}
-							</a>
-							<span v-if="linkIndex < condition.links.length - 1">, </span>
+							</a><span v-if="linkIndex < condition.links.length - 1">,&nbsp;</span>
 						</template>
 					</span>
 				</div>


### PR DESCRIPTION
Before
<img width="238" height="118" alt="image" src="https://github.com/user-attachments/assets/e3117b05-2209-43da-b6a5-3f2f11f38bd5" />


After
<img width="238" height="118" alt="image" src="https://github.com/user-attachments/assets/0b33c8cd-a1b2-4096-80b1-73658249d9ae" />
