### PR TITLE
Fix: Show error in UI when rule saving fails

### DIFF
--- a/modules/ext.rules/components/App.vue
+++ b/modules/ext.rules/components/App.vue
@@ -90,8 +90,8 @@ module.exports = defineComponent( {
 				);
 			}
 		}
+
 		// Watch for changes in rules and save them to the API
-		//return an error message if saving fails
 		watch( rules, async () => {
 			errorMessage.value = '';
 			try {
@@ -103,9 +103,7 @@ module.exports = defineComponent( {
 			}
 		}, { deep: true } );
 
-	}
-}, { deep: true } );
-
+		
 		return {
 			rules,
 			isFormVisible,
@@ -118,8 +116,10 @@ module.exports = defineComponent( {
 		};
 	}
 } );
-
 </script>
+
+
+
 <style scoped>
 .error-banner {
   background-color: #ffe6e6;

--- a/modules/ext.rules/composables/useRules.js
+++ b/modules/ext.rules/composables/useRules.js
@@ -82,7 +82,7 @@ function useRules( initialRules = [] ) {
 	} catch (error) {
 		console.error('Failed to save rules:', error);
 		saveError.value = error;
-		return null;
+		throw error;
 	} finally {
 		saving.value = false;
 	}

--- a/modules/ext.rules/composables/useRules.js
+++ b/modules/ext.rules/composables/useRules.js
@@ -5,6 +5,7 @@ const { ref } = require( 'vue' );
 /**
  * @typedef {object} RulesComposable
  * @property {import('vue').Ref<boolean>} saving
+ * @property {import('vue').Ref<string|null>} saveError
  * @property {import('vue').Ref<Rule[]>} rules
  * @property {( rule: Rule ) => Rule} addRule
  * @property {( originalRule: Rule, updatedRule: Rule ) => Rule | null} updateRule
@@ -18,6 +19,7 @@ const { ref } = require( 'vue' );
  */
 function useRules( initialRules = [] ) {
 	const saving = ref( false );
+	const saveError = ref(' ');
 	/** @type {import('vue').Ref<Rule[]>} */
 	const rules = ref( [ ...initialRules ] );
 
@@ -66,22 +68,30 @@ function useRules( initialRules = [] ) {
 	 * @param {string} title
 	 * @return {Promise<any>}
 	 */
-	async function saveRules( api, title ) {
-		saving.value = true;
-		try {
-			const content = JSON.stringify( { rules: rules.value } );
-			return await api.postWithToken( 'csrf', {
-				action: 'edit',
-				title,
-				text: content
-			} );
-		} finally {
-			saving.value = false;
-		}
+	async function saveRules(api, title) {
+	saving.value = true;
+	saveError.value = null;
+
+	try {
+		const content = JSON.stringify({ rules: rules.value });
+		return await api.postWithToken('csrf', {
+			action: 'edit',
+			title,
+			text: content
+		});
+	} catch (error) {
+		console.error('Failed to save rules:', error);
+		saveError.value = error;
+		return null;
+	} finally {
+		saving.value = false;
 	}
+}
+
 
 	return {
 		saving,
+		saveError,
 		rules,
 		addRule,
 		updateRule,


### PR DESCRIPTION
This PR enhances the user experience by adding proper UI feedback when saving rules fails due to API/network issues.

- Added errorMessage reactive ref
- Displayed error in <App.vue> using a styled banner
- Included graceful fallback in watch(rules) to notify the user via mw.notify

This is a follow-up to [#52](https://github.com/ProfessionalWiki/Rules/pull/52), which was closed due to a syntax issue.

Fixes [ProfessionalWiki/Rules#43](https://github.com/ProfessionalWiki/Rules/issues/43)