### PR TITLE
Fetch more matching categories

### DIFF
--- a/modules/ext.rules/utils/api.js
+++ b/modules/ext.rules/utils/api.js
@@ -52,7 +52,7 @@ async function searchCategories( api, query ) {
 			action: 'query',
 			list: 'allcategories',
 			acprefix: query,
-			aclimit: 10
+			aclimit: 50
 		},
 		'query.allcategories'
 	);


### PR DESCRIPTION
This search appears to be prefix search

On wikis where the prefix is common, entering the prefix and then looking through the results can be useful, but does not work well if there are more than 10 results, hence limit increase

The UI already gives a scrollbar with 10 results, so getting more should not create any issue